### PR TITLE
Prepare SQLite amalgamation before WASM Docker build

### DIFF
--- a/docker/sqlite-wasm.Dockerfile
+++ b/docker/sqlite-wasm.Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+FROM emscripten/emsdk:3.1.69
+
+WORKDIR /src
+
+# Clone the SQLite source tree and prepare the amalgamation for the WASM build.
+RUN git clone --depth 1 https://github.com/sqlite/sqlite.git
+
+WORKDIR /src/sqlite
+RUN ./configure --enable-all
+RUN make sqlite3.c
+
+# Build the JavaScript and WebAssembly artifacts from the canonical WASM makefile.
+WORKDIR /src/sqlite/ext/wasm
+RUN make dist


### PR DESCRIPTION
## Summary
- add a Dockerfile for building the sqlite WASM artifacts
- configure the sqlite source tree and build sqlite3.c before invoking the WASM make targets

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbe9753a4832588adde21106923d8