### PR TITLE
Update WASM Dockerfile to export jswasm artifacts

### DIFF
--- a/docker/sqlite-wasm.Dockerfile
+++ b/docker/sqlite-wasm.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM emscripten/emsdk:3.1.69
+FROM emscripten/emsdk:3.1.69 AS builder
 
 WORKDIR /src
 
@@ -14,3 +14,14 @@ RUN make sqlite3.c
 # Build the JavaScript and WebAssembly artifacts from the canonical WASM makefile.
 WORKDIR /src/sqlite/ext/wasm
 RUN make dist
+
+FROM scratch AS export
+COPY --from=builder \
+        /src/sqlite/ext/wasm/jswasm/sqlite3.js \
+        /src/sqlite/ext/wasm/jswasm/sqlite3.mjs \
+        /src/sqlite/ext/wasm/jswasm/sqlite3.wasm \
+        /src/sqlite/ext/wasm/jswasm/sqlite3-worker1.js \
+        /src/sqlite/ext/wasm/jswasm/sqlite3-worker1.mjs \
+        /src/sqlite/ext/wasm/jswasm/sqlite3-opfs-async-proxy.js \
+        /src/sqlite/ext/wasm/jswasm/sqlite3-opfs-async-proxy.mjs \
+        /


### PR DESCRIPTION
## Summary
- rename the build stage and add an export stage for sqlite wasm artifacts
- copy all required files from /src/sqlite/ext/wasm/jswasm so the container output includes every asset

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfc0a0229883258d25e5e8758f45ee